### PR TITLE
fix(docker): use npm ci instead of install in Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+node_modules/
+.git/
+*.md
+.dockerignore
+.eslintrc.js
+.gitignore
+.tool-versions
+Dockerfile
+Procfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,8 @@ ENV API_KEY \
 
 WORKDIR /usr/src/app
 
-COPY package.json .
-
-RUN npm install
-
 COPY . .
+
+RUN npm ci
 
 ENTRYPOINT ["node", "index.js"]


### PR DESCRIPTION
In the Dockerfile previously added to the project root directory

`npm install` has been replaced with `npm ci`

