### PR TITLE
Fix docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+node_modules/
+.git/
+*.md
+.dockerignore
+.eslintrc.js
+.gitignore
+.tool-versions
+Dockerfile
+Procfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,8 @@ ENV API_KEY \
 
 WORKDIR /usr/src/app
 
-COPY package.json .
-
-RUN npm install
-
 COPY . .
+
+RUN npm ci
 
 ENTRYPOINT ["node", "index.js"]


### PR DESCRIPTION
Hello,

I add a dockerignore file. To be sure we don't send to docker's context all data in current folder (.git folder, current node_modules folder).

It reduce amount of data sent from 32 MB to 290kB.

Then I ensure that we don't do any magic operation during node modules installation.

Using `npm ci` is mandatory on those context because we don't want to have a magic resolution of dependency. We want to stick to exact version listed in package-lock.json file.

For example it will not install a newer version, remember all that compromised dependency ...

To response to other topic listed here : https://github.com/guillaume-rygn/Twitter-header-bot/pull/8#issuecomment-1222470639

This Dockerfile should be made with the state of art and do not provide any way of testing if the repository is inconsistent. T hoses topics should be addressed by adding à CI pipeline like mentioned in https://github.com/guillaume-rygn/Twitter-header-bot/issues/11 . All commit need also to be consistent and all commit must build.